### PR TITLE
Changed nanoid dependency to a specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "nanoid": "latest"
+    "nanoid": "^2.x.x"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
It seems that the newer version of nanoid broken the way to require the function, this is a small change to make it work with the older version