### PR TITLE
Use exists instead of findBy on attemptToGenerate

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function nanoidPlugin(schema, opts) {
 
 function attemptToGenerate(doc, opts) {
 	const id = generator(opts)(opts.length);
-	return doc.constructor.findById(id)
+	return doc.constructor.exists({ _id: id })
 		.then(function (found) {
 			if (found) return attemptToGenerate(doc, opts.length);
 			return id


### PR DESCRIPTION
In the event of a collision during `attemptToGenerate`, the `findById` method will retrieve the whole document, by using `exists` we can be a little more efficient and just check the existence. 